### PR TITLE
Adding Vagrant and Docker support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bower_components
 cache
 vendor
+.vagrant

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM czeeb/tonis-docker-nginx
+
+ADD . /srv/www
+RUN chown -R www-data:www-data /srv/www
+
+WORKDIR /srv/www
+RUN setuser www-data composer install --no-dev -o
+RUN setuser www-data bower install --production 

--- a/README.md
+++ b/README.md
@@ -46,3 +46,30 @@ $routes->get('/hello/{name}', function ($name) {
 
 $tonis->run();
 ```
+
+Vagrant
+-------
+
+Tonis comes with a Vagrantfile.  Utilizing [Vagrant](https://www.vagrantup.com), the working directory will be synced with the virtualized environment.  You will need to have both [Vagrant](https://www.vagrantup.com) and [Docker](https://www.docker.com) installed.  You are responsible for running composer and bower from the host.
+
+```sh
+sudo vagrant up --provider=docker
+```
+
+SSH is not enabled, but you can still get a shell prompt in the container.
+
+```sh
+$ sudo docker ps
+CONTAINER ID        IMAGE                             COMMAND             CREATED             STATUS              PORTS                  NAMES
+45d0c5d94ee0        czeeb/tonis-docker-nginx:latest   "/sbin/my_init"     13 minutes ago      Up 13 minutes       0.0.0.0:8080->80/tcp   tonis_nginx_1433860664
+
+$ sudo docker exec -t -i tonis_nginx_1433860664 bash -l
+root@45d0c5d94ee0:/#
+```
+
+Docker
+------
+
+A Dockerfile has also been included.  The difference between using Vagrant and [Docker](https://www.docker.com) is that any changes made to the code after the Docker container has been created will not be reflected in the container.  The primary usage of the docker container is for production where code only changes on deployment.
+
+The Dockerfile takes care of running both composer and bower when the container is built.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,10 @@
+Vagrant.configure("2") do |config|
+  config.vm.define "nginx" do |v|
+    v.vm.provider "docker" do |d|
+      d.image = "czeeb/tonis-docker-nginx"
+      d.ports = ["8080:80"]
+      #d.cmd ["setuser", "www-data", "composer", "install", "--working-dir", "/srv/www"]
+    end
+    v.vm.synced_folder "./", "/srv/www"
+  end
+end


### PR DESCRIPTION
I've created https://github.com/czeeb/tonis-docker-nginx and set up integration with Docker Hub.  This made it a lot easier to use with Vagrant and allowed for vagrant-cachier to be used if it's in your global Vagrantfile.  It also made it easier to manage the Dockerfile in the tonis repository as a production environment.  The Dockerfile also opened the door for integration to be set up for tonis-io/tonis on Docker Hub allowing people to access the docker production environment directly and build up on.

I recommend we move the czeeb/tonis-docker-nginx repository into the tonis-io project.

I'd also like to create a tonis-docker-apache container as well to give people options.

No performance tuning was done on either nginx or fpm.  The settings are pretty basic and vanilla.